### PR TITLE
feat: support additional search paths for defaults list navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ The extension will automatically:
 * **`hydralance.showOutputOnError`** *(boolean, default: false)*  
   Automatically open the HydraLance output channel only when you explicitly opt in to seeing logs as soon as an internal error occurs
 
+* **`hydralance.additionalSearchPaths`** *(array, default: [])*  
+  List of extra directories (absolute or relative to the workspace folder) that should be searched when resolving entries in Hydra defaults lists
+
 ### Interpolation Resolution Settings  
 * **`hydralance.excludePatterns`** *(array, default: [".venv/**"])*  
   Glob patterns to exclude from YAML file indexing for interpolation resolution

--- a/package.json
+++ b/package.json
@@ -67,6 +67,14 @@
           "default": false,
           "description": "Automatically open the HydraLance output channel whenever the extension logs an internal error"
         },
+        "hydralance.additionalSearchPaths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Extra directories (absolute or workspace-relative) to search when resolving Hydra defaults entries"
+        },
         "hydralance.excludePatterns": {
           "type": "array",
           "items": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1233,12 +1233,17 @@ function resolveConfiguredPath(input: string | undefined, workspaceFolder: vscod
     return path.normalize(resolvedPath);
 }
 
+function isWithinWorkspaceRoot(workspaceRoot: string, candidatePath: string): boolean {
+    const relativePath = path.relative(workspaceRoot, candidatePath);
+    return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath));
+}
+
 function collectSearchDirectories(document: vscode.TextDocument, workspaceFolder: vscode.WorkspaceFolder): string[] {
     const workspaceRoot = workspaceFolder.uri.fsPath;
     const directories = new Set<string>();
     let currentPath = path.dirname(document.uri.fsPath);
 
-    while (currentPath.startsWith(workspaceRoot)) {
+    while (isWithinWorkspaceRoot(workspaceRoot, currentPath)) {
         directories.add(currentPath);
         const parentPath = path.dirname(currentPath);
         if (parentPath === currentPath) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1223,7 +1223,7 @@ function resolveConfiguredPath(input: string | undefined, workspaceFolder: vscod
         return undefined;
     }
 
-    let resolvedPath = trimmed.replace(/^~(?=$|\/)/, os.homedir());
+    let resolvedPath = trimmed.replace(/^~(?=$|\/|\\)/, os.homedir());
     resolvedPath = resolvedPath.replace(/\$\{workspaceFolder\}/g, workspaceFolder.uri.fsPath);
 
     if (!path.isAbsolute(resolvedPath)) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1213,6 +1213,54 @@ function stripYamlExtension(value: string): string {
     return value.replace(/\.(ya?ml)$/i, '');
 }
 
+function resolveConfiguredPath(input: string | undefined, workspaceFolder: vscode.WorkspaceFolder): string | undefined {
+    if (!input) {
+        return undefined;
+    }
+
+    const trimmed = input.trim();
+    if (!trimmed) {
+        return undefined;
+    }
+
+    let resolvedPath = trimmed.replace(/^~(?=$|\/)/, os.homedir());
+    resolvedPath = resolvedPath.replace(/\$\{workspaceFolder\}/g, workspaceFolder.uri.fsPath);
+
+    if (!path.isAbsolute(resolvedPath)) {
+        resolvedPath = path.join(workspaceFolder.uri.fsPath, resolvedPath);
+    }
+
+    return path.normalize(resolvedPath);
+}
+
+function collectSearchDirectories(document: vscode.TextDocument, workspaceFolder: vscode.WorkspaceFolder): string[] {
+    const workspaceRoot = workspaceFolder.uri.fsPath;
+    const directories = new Set<string>();
+    let currentPath = path.dirname(document.uri.fsPath);
+
+    while (currentPath.startsWith(workspaceRoot)) {
+        directories.add(currentPath);
+        const parentPath = path.dirname(currentPath);
+        if (parentPath === currentPath) {
+            break;
+        }
+        currentPath = parentPath;
+    }
+
+    directories.add(workspaceRoot);
+
+    const config = vscode.workspace.getConfiguration('hydralance', workspaceFolder.uri);
+    const additionalPaths = config.get<string[]>('additionalSearchPaths', []);
+    for (const userPath of additionalPaths) {
+        const resolved = resolveConfiguredPath(userPath, workspaceFolder);
+        if (resolved) {
+            directories.add(resolved);
+        }
+    }
+
+    return Array.from(directories);
+}
+
 // Common function to find target path for defaults entries
 function findTargetPathForDefaults(
     document: vscode.TextDocument,
@@ -1246,29 +1294,20 @@ function findTargetPathForDefaults(
         return undefined;
     }
 
-    let currentPath = path.dirname(document.uri.fsPath);
     const workspaceRoot = workspaceFolder.uri.fsPath;
+    const searchDirectories = collectSearchDirectories(document, workspaceFolder);
 
-    while (currentPath.startsWith(workspaceRoot)) {
+    for (const basePath of searchDirectories) {
         for (const relativePath of relativePaths) {
-            const fullPath = path.join(currentPath, relativePath);
+            const fullPath = path.join(basePath, relativePath);
             if (fs.existsSync(fullPath)) {
-                // Return the relative path from workspace root for a cleaner display
-                return { 
-                    path: path.relative(workspaceRoot, fullPath), 
+                return {
+                    path: path.relative(workspaceRoot, fullPath),
                     exists: true,
-                    fullPath: fullPath
+                    fullPath
                 };
             }
         }
-        
-        // Move one directory up
-        const parentPath = path.dirname(currentPath);
-        if (parentPath === currentPath) {
-            // Reached the root of the file system
-            break;
-        }
-        currentPath = parentPath;
     }
 
     // If file doesn't exist, still show the expected path


### PR DESCRIPTION
## Summary

Adds a new `hydralance.additionalSearchPaths` setting that allows users to specify extra directories to search when resolving Hydra defaults entries. This addresses the case where Hydra search paths are configured via `hydra.searchpath` and config files live outside the standard directory hierarchy.

## Changes

- **`resolveConfiguredPath()`** — resolves user-provided paths, supporting `~`, `${workspaceFolder}`, relative, and absolute paths
- **`collectSearchDirectories()`** — combines the existing upward directory walk with user-configured additional paths into a unified search list
- **`findTargetPathForDefaults()`** — refactored to use `collectSearchDirectories()` instead of inline directory walking
- **`package.json`** — registers the new `hydralance.additionalSearchPaths` array setting
- **`README.md`** — documents the new setting

## Usage

```json
{
  "hydralance.additionalSearchPaths": [
    "configs/extra",
    "/absolute/path/to/configs",
    "~/my-configs"
  ]
}
```

Closes #1